### PR TITLE
[DP-894] Fix npm and git bugs

### DIFF
--- a/lib/core/git/step.sh
+++ b/lib/core/git/step.sh
@@ -51,7 +51,7 @@ function ih::setup::core.git::install() {
   ih::setup::core.git::private::set-if-unset "push.default" "simple"
 
   # make git use ssh for everything
-  git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+  git config --global url.ssh://git@github.com/ConsultingMD/.insteadOf https://github.com/ConsultingMD
 
   # set up pre-commit to automatically be set up for all cloned repos,
   # if the user doesn't have a templateDir already


### PR DESCRIPTION
This fixes a bug with the cert setup for
npm and yarn by mixing the DLP cert into
the Mozilla cert bundle, so those tools
will work correctly whether on the VPN or
not. Previously npm would not work when
not on the VPN (or when contacting a host
that is excluded from DLP) because the cert
bundle did not include any other root
certificates and npm would not fail back
to the system certs.

This also fixes a possible issue where
all GitHub orgs were being forced to
interact over SSH when we really only
need to force ConsultingMD repos to use
SSH.
