### PR TITLE
[DP-1302] don't step on SHELL

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ConsultingMD/platform
+* @ConsultingMD/developer-platform

--- a/lib/core/shell/custom/99_bash.sh
+++ b/lib/core/shell/custom/99_bash.sh
@@ -5,7 +5,6 @@
 # module is updated
 
 # Only continue if we're on bash
-SHELL=$(ps -cp "$$" -o command="")
-if [[ ! $SHELL =~ "bash" ]]; then
+if [[ ! $(ps -cp "$$" -o command="") =~ "bash" ]]; then
   return 0
 fi

--- a/lib/core/shell/custom/99_zsh.sh
+++ b/lib/core/shell/custom/99_zsh.sh
@@ -6,7 +6,6 @@
 # formula is updated
 
 # Only continue if we're on zsh
-SHELL=$(ps -cp "$$" -o command="")
-if [[ ! $SHELL =~ "zsh" ]]; then
+if [[ ! $(ps -cp "$$" -o command="") =~ "zsh" ]]; then
   return 0
 fi

--- a/lib/core/shell/default/99_bash.sh
+++ b/lib/core/shell/default/99_bash.sh
@@ -13,8 +13,7 @@
 # Changes will be overwritten if you update the ih-core formula
 
 # Only continue if we're on bash
-SHELL=$(ps -cp "$$" -o command="")
-if [[ ! $SHELL =~ "bash" ]]; then
+if [[ ! $(ps -cp "$$" -o command="") =~ "bash" ]]; then
   return 0
 fi
 

--- a/lib/core/shell/default/99_zsh.sh
+++ b/lib/core/shell/default/99_zsh.sh
@@ -14,8 +14,7 @@
 # Changes to this file will be overwritten if you update the ih-core formula
 
 # Only continue if we're on zsh
-SHELL=$(ps -cp "$$" -o command="")
-if [[ ! $SHELL =~ "zsh" ]]; then
+if [[ ! $(ps -cp "$$" -o command="") =~ "zsh" ]]; then
   return 0
 fi
 


### PR DESCRIPTION
This avoids stepping on the SHELL env var,
so it doesn't get messed up when the 
process name is not a shell name.