### PR TITLE
Use correct path for x86 rancher

### DIFF
--- a/Casks/ih-rancher.rb
+++ b/Casks/ih-rancher.rb
@@ -2,7 +2,7 @@ cask "ih-rancher" do
     version "1.7.0"
 
     if Hardware::CPU.intel? 
-        url "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v#{version}/Rancher.Desktop-v#{version}.x86_64.dmg"
+        url "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v#{version}/Rancher.Desktop-#{version}.x86_64.dmg"
         sha256 "828dde44868c3c33fe709e099f9af080143a379f9fba2e3bacd8641f5ad8e72b"
     else
         url "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v#{version}/Rancher.Desktop-#{version}.aarch64.dmg"


### PR DESCRIPTION
This doesn't need a version bump because that cask is only installed by the bootstrap script or by a manual `brew install ih-rancher`.