### PR TITLE
[DT-53] Auto-update tool repositories

### DIFF
--- a/lib/core/toolrepos/autoupdate/com.includedhealth.auto-update-repositories.plist
+++ b/lib/core/toolrepos/autoupdate/com.includedhealth.auto-update-repositories.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.includedhealth.auto-update-repositories.plist</string>
+    <key>Program</key>
+    <string>$IH_HOME/homebrew-ih-public/lib/core/toolrepos/autoupdate/ih_auto_update_repositories.sh</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>IH_HOME</key>
+        <string>$IH_HOME</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/ih_auto_update_repositories.stdout</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/ih_auto_update_repositories.stderr</string>
+    <key>StartInterval</key>
+    <integer>3600</integer>
+</dict>
+</plist>

--- a/lib/core/toolrepos/autoupdate/ih_auto_update_repositories.sh
+++ b/lib/core/toolrepos/autoupdate/ih_auto_update_repositories.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+repos=(engineering image-builder)
+
+for repo in "${repos[@]}" ; do
+    cd "$IH_HOME/$repo" || exit 1
+
+    # Saves our current and main/master branch of the repository
+    currentBranch=$(git branch --show-current)
+    mainBranch=$(git branch | tr " " "\n" | grep -E "(main|master)")
+
+    # If we cannot find the main branch, skip over this repository
+    if [[ -z "$mainBranch" ]]; then
+        echo "Failed to find the main branch, skipping this git repository"
+        continue
+    fi
+
+    # Switch to our main branch
+    if [[ "$currentBranch" != "$mainBranch" ]]; then
+        git checkout "$mainBranch"
+    fi
+
+    # Save any pending changes
+    gitStash=$(git stash)
+    gitPull=$(git pull)
+
+
+    # Short-circuit if we have the latest changes
+    if [[ "$gitPull" == "Already up to date." && "$currentBranch" != "$mainBranch" ]]; then
+        git checkout "$currentBranch"
+        continue
+    fi
+
+    # Revert pending changes
+    if [[ "$gitStash" != "No local changes to save" ]]; then
+        git stash pop
+    fi
+
+    # Switch back to our existing branch
+    if [[ "$currentBranch" != "$mainBranch" ]]; then
+        git checkout "$currentBranch"
+    fi
+done

--- a/lib/core/toolrepos/step.sh
+++ b/lib/core/toolrepos/step.sh
@@ -67,4 +67,24 @@ function ih::setup::core.toolrepos::test-or-install() {
   export IH_WANT_RE_SOURCE=1
 
   cp -f "$toolsrepo_src_path" "$toolsrepo_tgt_path"
+
+  ih::setup::core.toolrepos::set-auto-update-repositories-job
+
+}
+
+function ih::setup::core.toolrepos::set-auto-update-repositories-job() {
+
+  local THIS_DIR="$IH_CORE_LIB_DIR/core/toolrepos/autoupdate"
+
+  PLIST_FILE="com.includedhealth.auto-update-repositories"
+  LAUNCH_AGENTS_PATH="${HOME}/Library/LaunchAgents/${PLIST_FILE}.plist"
+  
+  sed "s/\$IH_HOME/${GR_HOME}/g" "${THIS_DIR}/${PLIST_FILE}.plist" > "${LAUNCH_AGENTS_PATH}"
+
+  if launchctl list | grep -q ${PLIST_FILE} ; then
+    launchctl unload "${LAUNCH_AGENTS_PATH}"
+  fi
+
+  launchctl load "${LAUNCH_AGENTS_PATH}"
+
 }


### PR DESCRIPTION
This configures a new `launchd` job that runs every hour to update the `engineering` and `image-builder` repositories.
It helps to get the last features and fixes up-to-date automatically.