### PR TITLE
CLOUD-1422: add BUNDLE_MIRROR__GEM__FURY__IO to default/00_env.sh

### DIFF
--- a/lib/core/shell/default/00_env.sh
+++ b/lib/core/shell/default/00_env.sh
@@ -2,7 +2,7 @@
 
 # This file defines the common environment variables
 # which the Platform team has found to be useful.
-# You can override thes values in the env_custom.sh file.
+# You can override these values in the env_custom.sh file.
 
 # ██████╗  ██████╗     ███╗   ██╗ ██████╗ ████████╗    ███████╗██████╗ ██╗████████╗
 # ██╔══██╗██╔═══██╗    ████╗  ██║██╔═══██╗╚══██╔══╝    ██╔════╝██╔══██╗██║╚══██╔══╝
@@ -23,3 +23,6 @@ export IH_AUGMENT_SOURCED=yes
 
 # Allow importing of private repos in GO
 export GOPRIVATE="github.com/ConsultingMD/*"
+
+# Allow installing gems from a proxy that automatically authenticates when on the internal network
+export BUNDLE_MIRROR__GEM__FURY__IO="https://gems.includedhealth.com/doctorondemand/"


### PR DESCRIPTION
@ethomson1 recently ran into an issue where she got an error downloading a private dependency due to the gemfury changes.

The bundle command would have worked outside the container if we set this automatically on dev machines with ih-setup:
```
BUNDLE_MIRROR__GEM__FURY__IO="https://gems.includedhealth.com/doctorondemand/" 
```

This PR makes a change to ih-setup so bundle works outside of the container with private dependencies while you’re on the VPN.