### PR TITLE
[DP-2579] Upgrade ih-setup pre-commit

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 ruby 2.7.2
 python 3.9.7
-pre-commit 2.15.0
+pre-commit 3.2.2
 shfmt 3.4.1
 shellcheck 0.8.0

--- a/lib/core/asdf/.tool-versions
+++ b/lib/core/asdf/.tool-versions
@@ -4,7 +4,7 @@ golang 1.16.3
 helm 3.6.1
 nodejs 16.2.0
 protoc 3.17.3
-pre-commit 2.15.0
+pre-commit 3.2.2
 ruby 2.7.2
 terraform 1.0.3
 vault 1.8.3


### PR DESCRIPTION
**Problem**

When using pre-commit 2.15.0, it lacks a [very helpful error message ](https://github.com/pre-commit/pre-commit/blob/5027592625f8df286dea831e84e7bf83021b7c1b/pre_commit/repository.py#L104)when
python hooks are incompatible with the python environment being used.

**Proposal**

Upgrade pre-commit in `/lib/core/asdf/.tool-versions` from 2.15.0 to 3.2.2

**Impact**

- engineers can more easily debug python hook issues
