### PR TITLE
CLOUD-1886: Remove hardcoded version from rancher desktop deployment profile

### DIFF
--- a/lib/core/rancher/io.rancherdesktop.profile.defaults.plist
+++ b/lib/core/rancher/io.rancherdesktop.profile.defaults.plist
@@ -117,8 +117,6 @@
 		<key>includeKubernetesServices</key>
 		<false/>
 	</dict>
-	<key>version</key>
-	<integer>6</integer>
 	<key>virtualMachine</key>
 	<dict>
 		<key>hostResolver</key>

--- a/lib/core/rancher/io.rancherdesktop.profile.defaults.plist
+++ b/lib/core/rancher/io.rancherdesktop.profile.defaults.plist
@@ -111,8 +111,6 @@
 		</dict>
 		<key>port</key>
 		<integer>6443</integer>
-		<key>version</key>
-		<string>1.25.7</string>
 	</dict>
 	<key>portForwarding</key>
 	<dict>


### PR DESCRIPTION
@jenriquecerdaih and I just ran an issue after he upgraded from rancher desktop 1.8.1 to 1.9.0:
> Error Starting Kubernetes
> Error in deployment profiles:
> Changing field version via the API isn’t supported.

This is likely happening because it doesn't support having the version hardcoded after it's changed in more recent versions.

This PR removes the hardcoded version from the deployment profile to prevent the error.