### PR TITLE
[DP-2630] Add mkcert plugin

### DIFF
--- a/lib/core/asdf/.tool-versions
+++ b/lib/core/asdf/.tool-versions
@@ -1,10 +1,11 @@
-python 3.9.7
 buf 0.51.1
 golang 1.16.3
 helm 3.6.1
+mkcert 1.4.4
 nodejs 16.2.0
-protoc 3.17.3
 pre-commit 3.2.2
+protoc 3.17.3
+python 3.9.7
 ruby 2.7.2
 terraform 1.0.3
 vault 1.8.3


### PR DESCRIPTION
This allows users to add `mkcert` to their .tool-versions. I also used vim's sort functionality to sort the .tool-versions file.