### PR TITLE
Remove unused virtualenv dependency

### DIFF
--- a/formula/ih-core.rb
+++ b/formula/ih-core.rb
@@ -15,7 +15,6 @@ class IhCore < Formula
   depends_on "jq"
   depends_on "yq"
   depends_on "go-jira"
-  depends_on "virtualenv"
   depends_on "envconsul"
   depends_on "openssl@3"
   depends_on "coreutils"


### PR DESCRIPTION
We shouldn't need to require the virtualenv dependency after this change to use venv instead: https://github.com/ConsultingMD/image-builder/pull/221

This PR removes the `depends_on` for `virtualenv`.