### PR TITLE
[DP-3498] Update the set-auto-update-repositories tool to use IH_CORE_DIR path

### DIFF
--- a/lib/core/toolrepos/autoupdate/com.includedhealth.auto-update-repositories.plist
+++ b/lib/core/toolrepos/autoupdate/com.includedhealth.auto-update-repositories.plist
@@ -6,7 +6,7 @@
     <key>Label</key>
     <string>com.includedhealth.auto-update-repositories</string>
     <key>Program</key>
-    <string>$IH_HOME/homebrew-ih-public/lib/core/toolrepos/autoupdate/ih_auto_update_repositories.sh</string>
+    <string>$IH_CORE_LIB_DIR/core/toolrepos/autoupdate/ih_auto_update_repositories.sh</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>IH_HOME</key>

--- a/lib/core/toolrepos/step.sh
+++ b/lib/core/toolrepos/step.sh
@@ -109,10 +109,12 @@ function ih::setup::core.toolrepos::set-auto-update-repositories-job() {
 
   # shellcheck disable=SC2001
   GR_HOME_ESC=$(echo "$GR_HOME" | sed 's_/_\\/_g')
+  # shellcheck disable=SC2001
+  IH_CORE_LIB_DIR_ESC=$(echo "$IH_CORE_LIB_DIR" | sed 's_/_\\/_g')
 
-  sed "s/\$IH_HOME/${GR_HOME_ESC}/g" "${THIS_DIR}/${PLIST_FILE}.plist" >"${LAUNCH_AGENTS_PATH}"
+  sed "s/\$IH_HOME/${GR_HOME_ESC}/g; s/\$IH_CORE_LIB_DIR/${IH_CORE_LIB_DIR_ESC}/g" "${THIS_DIR}/${PLIST_FILE}.plist" >"${LAUNCH_AGENTS_PATH}"
 
-  if launchctl list | grep -q ${PLIST_FILE}; then
+  if launchctl list | grep -e ${PLIST_FILE}; then
     launchctl unload "${LAUNCH_AGENTS_PATH}"
   fi
 


### PR DESCRIPTION
What does this do?
[DP-3498 ih-setup: auto-update tool repositories doesn't work for everyone](https://includedhealth.atlassian.net/browse/DP-3498)

This fixes the issue where the automatic repository update tool only works for people who have cloned the `homebrew-ih-public` repository by removing it from the .plist file to use the `IH_CORE_DIR` path instead.