### PR TITLE
Prevent permissions error on rancher plist file

### DIFF
--- a/lib/core/rancher/step.sh
+++ b/lib/core/rancher/step.sh
@@ -123,6 +123,8 @@ function ih::setup::core.rancher::install() {
   echo "A configuration file for Rancher Desktop will be copied to your system"
   echo "You may be required to enter your password"
   sudo cp "$TEMP_PLIST_DST" "$PLIST_DST"
+  sudo chown $USER:staff "$PLIST_DST"
+  sudo chmod 644 "$PLIST_DST"
 
   # Check if Rancher was installed manually
   brew list rancher >/dev/null 2>&1


### PR DESCRIPTION
Fixes:
```
Failed to load the deployment profile
Error reading file /Users/kevin.maldonado/Library/Preferences/io.rancherdesktop.profile.defaults.plist: Error: EACCES: permission denied, open '/Users/kevin.maldonado/Library/Preferences/io.rancherdesktop.profile.defaults.plist'
```