### PR TITLE
CLOUD-4780: improve error message when running ih-setup check

### DIFF
--- a/bin/ih-setup
+++ b/bin/ih-setup
@@ -223,7 +223,13 @@ function ih::private::apply-to-steps() {
 
   if [[ $STEP_ERROR -gt 0 ]]; then
     if [[ $COMMAND = 'test-step' ]]; then
-      ih::log::error "One or more dependencies missing. Re-run using 'ih-setup -v install' for more details."
+      if [[ ${#} -eq 0 ]]; then
+        # When checking all steps
+        ih::log::error "One or more steps need to be installed. Re-run using 'ih-setup -v install' for more details."
+      else
+        # When checking specific steps
+        ih::log::error "One or more dependencies missing. Re-run using 'ih-setup -v install' for more details."
+      fi
     else
       ih::log::error "Re-run using 'ih-setup -v install' for more details."
     fi


### PR DESCRIPTION
Related to: https://github.com/ConsultingMD/homebrew-ih-public/pull/105

Seems like the "One or more dependencies missing" error when running `ih-setup check` is actually not accurate. When running `ih-setup check` without specific steps, it checks all steps in the system and reports this dependency error message even when steps simply haven't been installed yet, regardless of whether they're dependencies of other steps.

For example, if `core.jira` hasn't been installed but nothing depends on it, the current error message incorrectly suggests there are missing dependencies when really the step just hasn't been installed yet.

This PR updates the error message to be more accurate when checking all steps vs checking specific steps with dependencies.

Before:
```
$ ih-setup check
...
FAIL: Command test-step failed for step core.jira
FAIL: One or more dependencies missing. Re-run using 'ih-setup -v install' for more details.
```

After:
```
$ ih-setup check
...
FAIL: Command test-step failed for step core.jira
FAIL: One or more steps need to be installed. Re-run using 'ih-setup -v install' for more details.
```