### PR TITLE
CLOUD-5020: add asdf shell script sync check

### DIFF
--- a/lib/core/asdf/step.sh
+++ b/lib/core/asdf/step.sh
@@ -34,6 +34,11 @@ function ih::setup::core.asdf::test() {
     return 1
   fi
 
+  if ! ih::file::check-file-in-sync "$ASDF_SH_TEMPLATE_PATH" "$ASDF_SH_PATH"; then
+    ih::log::debug "asdf augment file is out of sync with template"
+    return 1
+  fi
+
   local CURRENT_PLUGINS
   CURRENT_PLUGINS=$(asdf plugin list)
   local DESIRED_PLUGINS


### PR DESCRIPTION
This PR adds a file synchronization check to ensure the asdf shell augment file (90_asdf.sh) stays up-to-date with our template. This is a first step toward adding backwards compatibility logic that will handle both the Bash-based asdf v0.14.1 and the newer Go-based asdf v0.16.0+.

The change:
- Adds a check in the test function to detect when 90_asdf.sh is out of sync
- Ensures the shell script is always updated during installation

This lays the groundwork for future changes that will make our asdf integration more robust across different versions.