### PR TITLE
DP-4818: Try and fast-forward if not on default branch

### DIFF
--- a/lib/core/toolrepos/autoupdate/ih_auto_update_repositories.sh
+++ b/lib/core/toolrepos/autoupdate/ih_auto_update_repositories.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 
-repos=(engineering image-builder)
+# These repos are needed to be kept up to date
+# as they are used daily in the SDLC.
+repos=(engineering image-builder janus temporal kafka ih-observability)
 
-for repo in "${repos[@]}" ; do
-    cd "$IH_HOME/$repo" || exit 1
+for repo in "${repos[@]}"; do
+  cd "$IH_HOME/$repo" || exit 1
 
-    currentBranch=$(git branch --show-current)
-    defaultBranch=$(git  branch -rl '*/HEAD' | rev | cut -d/ -f1 | rev)
+  currentBranch=$(git branch --show-current)
+  defaultBranch=$(git branch -rl '*/HEAD' | rev | cut -d/ -f1 | rev)
 
-    # Do git pull only if the default branch is checked out.
-    if [[ "$currentBranch" == "$defaultBranch" ]]; then
-        git pull
-    fi
+  # Do git pull only if the default branch is checked out.
+  if [[ "$currentBranch" == "$defaultBranch" ]]; then
+    git pull
+  else
+    # Try to pull the latest into the current branch instead
+    git pull origin "$defaultBranch" --ff-only --autostash
+  fi
 
 done


### PR DESCRIPTION
Our auto update script will update your repo only if you are on the default branch.

Sometimes these repos won't be on the default branch. So try our best to pull the latest into the current branch using a fast-forward, and abort if not. We also autostash changes if they exist.

This also adds some more development repos to the list of auto-updated repos.