### PR TITLE
[INTC-3129] Bumping pre-commit version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: script-must-not-have-extension
       - id: shfmt
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.20
+    rev: v0.1.30
     hooks:
       - id: shellcheck
         types:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 ruby 2.7.2
 python 3.9.7
-pre-commit 3.6.2
+pre-commit 4.3.0
 shfmt 3.4.1
 shellcheck 0.8.0

--- a/lib/core/asdf/.tool-versions
+++ b/lib/core/asdf/.tool-versions
@@ -3,7 +3,7 @@ golang 1.21.0
 helm 3.6.1
 mkcert 1.4.4
 nodejs 16.2.0
-pre-commit 3.6.2
+pre-commit 4.3.0
 protoc 24.3
 python 3.9.7
 ruby 2.7.2


### PR DESCRIPTION
[INTC-3129](https://includedhealth.atlassian.net/browse/INTC-3129)

I thought this was the right place: https://github.com/ConsultingMD/image-builder/pull/543

But it tisn't: https://ih-epdd.slack.com/archives/C03G7JD312M/p1758051488288559thread_ts=1758043282.189669&cid=C03G7JD312M

[INTC-3129]: https://includedhealth.atlassian.net/browse/INTC-3129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ