### PR TITLE
Enhance path deduplication comment in 99_zsh.sh

### DIFF
--- a/lib/core/shell/default/99_zsh.sh
+++ b/lib/core/shell/default/99_zsh.sh
@@ -74,9 +74,9 @@ fi
 autoload -Uz compinit
 compinit
 
-# Deduplicate path
+# Deduplicate path via zsh magic
 # shellcheck disable=SC2034
-typeset -U PATH path
+path=($path)
 
 # ██████╗  ██████╗     ███╗   ██╗ ██████╗ ████████╗    ███████╗██████╗ ██╗████████╗
 # ██╔══██╗██╔═══██╗    ████╗  ██║██╔═══██╗╚══██╔══╝    ██╔════╝██╔══██╗██║╚══██╔══╝


### PR DESCRIPTION
In some weird situations, `typeset -U` just erases the PATH. Gemini says the new way of deduplicating is safer and it does seem to work.