### PR TITLE
fix(zsh): remove duplicate compinit from IH augment

### DIFF
--- a/lib/core/shell/default/99_zsh.sh
+++ b/lib/core/shell/default/99_zsh.sh
@@ -71,9 +71,9 @@ if type brew &>/dev/null; then
   FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
 fi
 
-autoload -Uz compinit
-compinit
-
+# compinit: do not run here — duplicates ~/.zshrc when compinit runs after augment.sh.
+# In ~/.zshrc, after sourcing "$HOME/.ih/augment.sh", set fpath (plugins, etc.), then once:
+#   autoload -Uz compinit && compinit -C -d "$ZSH_COMPDUMP"  # or compinit -d on first run
 
 # ██████╗  ██████╗     ███╗   ██╗ ██████╗ ████████╗    ███████╗██████╗ ██╗████████╗
 # ██╔══██╗██╔═══██╗    ████╗  ██║██╔═══██╗╚══██╔══╝    ██╔════╝██╔══██╗██║╚══██╔══╝


### PR DESCRIPTION
## Summary

- Remove `compinit` from `lib/core/shell/default/99_zsh.sh` (sourced via `augment.sh`)
- Add comments: run `compinit` once in `~/.zshrc` after augment, once `fpath` is final

## Problem

Engineers with `compinit` in `~/.zshrc` after `augment.sh` paid for two full `compinit` runs every login (IH + user).

## Test plan

- [x] `zsh -i` — completions work (fzf-tab, brew, etc.)
- [x] `zprof` or timing — one `compinit`, not two
- [x] Fresh `~/.zshrc` with only `augment.sh` — add documented `compinit` block if needed

@cursor review

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shell-startup change; users who relied only on IH for completions must add the documented `compinit` block in `~/.zshrc`.
> 
> **Overview**
> Stops IH’s default zsh augment (`99_zsh.sh`, via `augment.sh`) from calling **`compinit`**, so interactive shells that already initialize completions in **`~/.zshrc`** after augment no longer pay for two full runs on every login.
> 
> Brew **`FPATH`** wiring is unchanged; inline comments now tell engineers to run **`autoload -Uz compinit && compinit`** once in **`~/.zshrc`** after augment, once **`fpath`** (plugins, etc.) is final.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea49dace0463a435e02fba0075331b44d1ff0a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->