### PR TITLE
feat: add claude-code@latest cask (GitHub release mirror, VPN-safe)

### DIFF
--- a/Casks/claude-code@latest.rb
+++ b/Casks/claude-code@latest.rb
@@ -1,0 +1,30 @@
+cask "claude-code@latest" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.1.154"
+  sha256 arm:    "643ec0cfa324744c15f6bf552d3ce6e934c42651b56f40ea8d4ec4f653a9b49f",
+         x86_64: "352e504e405a25e5f2b44ae3758b6dced15371c5411486b2c3add4c3ac4a5000"
+
+  url "https://github.com/anthropics/claude-code/releases/download/v#{version}/claude-darwin-#{arch}.tar.gz"
+  name "Claude Code"
+  desc "Terminal-based AI coding assistant (GitHub release mirror — VPN-safe)"
+  homepage "https://claude.com/product/claude-code"
+
+  livecheck do
+    url "https://github.com/anthropics/claude-code/releases/latest"
+    strategy :github_latest
+  end
+
+  binary "claude"
+
+  zap trash: [
+        "~/.cache/claude",
+        "~/.claude.json*",
+        "~/.config/claude",
+        "~/.local/bin/claude",
+        "~/.local/share/claude",
+        "~/.local/state/claude",
+        "~/Library/Caches/claude-cli-nodejs",
+      ],
+      rmdir: "~/.claude"
+end


### PR DESCRIPTION
## Summary

- Adds `Casks/claude-code@latest.rb` — a mirror of the official `homebrew-cask/claude-code@latest` cask that downloads from GitHub releases instead of `downloads.claude.ai`
- `downloads.claude.ai` is blocked on the IH VPN, making the official cask and `npm install -g @anthropic-ai/claude-code` (now deprecated upstream) unusable for engineers on VPN
- This cask uses the identical binary from `github.com/anthropics/claude-code/releases` with the same checksums

## Install

```bash
brew tap ConsultingMD/ih-public
brew install --cask claude-code@latest
```

## Updating

The `livecheck` strategy points to GitHub releases latest, so `brew upgrade` will pick up new versions automatically (once the cask version is bumped).

## Test plan

- [ ] `brew install --cask ConsultingMD/ih-public/claude-code@latest` on arm64 Mac (on VPN)
- [ ] `claude --version` returns `2.1.154`
- [ ] Verify checksum matches `SHASUMS256.txt` from the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New packaging-only cask with pinned checksums; no application runtime or auth logic changes in this repo.
> 
> **Overview**
> Adds a new Homebrew cask **`claude-code@latest`** so engineers can install Claude Code from this tap when the official download host is unreachable on VPN.
> 
> The cask pins **2.1.154** with arm64/x64 **SHA256** checksums, pulls **`claude-darwin-{arch}.tar.gz`** from **GitHub releases** (not `downloads.claude.ai`), installs the **`claude`** binary, uses **`:github_latest`** livecheck, and defines **`zap`** paths for Claude config/cache cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da30aea4dcdad4399566bf9f69ddb95e91b9ead4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->