### PR TITLE
feat: add claude-code cask (stable, GitHub release mirror, VPN-safe)

### DIFF
--- a/Casks/claude-code.rb
+++ b/Casks/claude-code.rb
@@ -1,0 +1,33 @@
+cask "claude-code" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.1.145"
+  sha256 arm:    "a385eb18d127b55cf2b1846d0a1771db335d9fdb1f6d1181f79343f61c95ba91",
+         x86_64: "4ad91d8572e242d860308319930f04f1110c6301670eef4ba896f02b9759e177"
+
+  url "https://github.com/anthropics/claude-code/releases/download/v#{version}/claude-darwin-#{arch}.tar.gz"
+  name "Claude Code"
+  desc "Terminal-based AI coding assistant (GitHub release mirror — VPN-safe)"
+  homepage "https://claude.com/product/claude-code"
+
+  livecheck do
+    url "https://github.com/anthropics/claude-code/releases"
+    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  conflicts_with cask: "claude-code@latest"
+
+  binary "claude"
+
+  zap trash: [
+        "~/.cache/claude",
+        "~/.claude.json*",
+        "~/.config/claude",
+        "~/.local/bin/claude",
+        "~/.local/share/claude",
+        "~/.local/state/claude",
+        "~/Library/Caches/claude-cli-nodejs",
+      ],
+      rmdir: "~/.claude"
+end


### PR DESCRIPTION
## Summary

- Adds `Casks/claude-code.rb` — mirrors the official `homebrew-cask/claude-code` (stable channel) but downloads from GitHub releases instead of `downloads.claude.ai`
- Companion to #147 (`claude-code@latest`); together they cover both channels

## Install

```bash
brew tap ConsultingMD/ih-public
brew install --cask claude-code          # stable (2.1.145)
brew install --cask claude-code@latest   # latest (2.1.154)
```

## Test plan

- [ ] `brew install --cask ConsultingMD/ih-public/claude-code` on arm64 Mac (on VPN)
- [ ] `claude --version` returns `2.1.145`
- [ ] Verify checksum matches `SHASUMS256.txt` from the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New packaging-only cask with pinned version and checksums; no application runtime or auth logic changes.
> 
> **Overview**
> Adds a new Homebrew cask **`claude-code`** for the **stable** Claude Code CLI (pinned at **2.1.145**), installing the `claude` binary from **GitHub releases** instead of `downloads.claude.ai` so installs work on VPN-restricted networks.
> 
> The cask mirrors the upstream stable channel pattern: **arm64/x64** checksums, **livecheck** against GitHub releases, **`conflicts_with`** **`claude-code@latest`**, and the same **`zap`** paths as the companion latest cask.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee193d383a00d2564846c891c0578d2f4ba3b200. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->