### PR TITLE
ci: add daily auto-update workflow for claude-code casks

### DIFF
--- a/.github/workflows/update-claude-code-casks.yml
+++ b/.github/workflows/update-claude-code-casks.yml
@@ -80,8 +80,10 @@ jobs:
           printf 'Automated update of the Claude Code GitHub mirror casks.\n\nstable: %s\nlatest: %s\n\nChecksums sourced from upstream SHASUMS256.txt on each GitHub release.' \
             "$STABLE_VER" "$LATEST_VER" > /tmp/pr-body.txt
 
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "chore: update claude-code casks (stable=${STABLE_VER}, latest=${LATEST_VER})" \
             --body-file /tmp/pr-body.txt \
             --base master \
-            --head "$BRANCH"
+            --head "$BRANCH")
+
+          gh pr merge --squash --auto "$PR_URL" || echo "Auto-merge not available (code owner review required); PR opened for manual merge."

--- a/.github/workflows/update-claude-code-casks.yml
+++ b/.github/workflows/update-claude-code-casks.yml
@@ -1,0 +1,87 @@
+name: update-claude-code-casks
+
+on:
+  schedule:
+    - cron: '0 9 * * *'  # Daily at 9am UTC
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get upstream versions
+        id: upstream
+        run: |
+          DIST_TAGS=$(npm view @anthropic-ai/claude-code dist-tags --json)
+          echo "stable=$(echo "$DIST_TAGS" | jq -r '.stable')" >> "$GITHUB_OUTPUT"
+          echo "latest=$(echo "$DIST_TAGS"  | jq -r '.latest')" >> "$GITHUB_OUTPUT"
+
+      - name: Get current cask versions
+        id: current
+        run: |
+          echo "stable=$(grep -m1 'version ' Casks/claude-code.rb | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+          echo "latest=$(grep -m1 'version ' 'Casks/claude-code@latest.rb' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+
+      - name: Update stable cask
+        if: steps.upstream.outputs.stable != steps.current.outputs.stable
+        env:
+          NEW_VER: ${{ steps.upstream.outputs.stable }}
+          OLD_VER: ${{ steps.current.outputs.stable }}
+        run: |
+          curl -fsSL "https://github.com/anthropics/claude-code/releases/download/v${NEW_VER}/SHASUMS256.txt" \
+            -o /tmp/shasums-stable.txt
+          ARM64=$(awk '/claude-darwin-arm64\.tar\.gz/{print $1}' /tmp/shasums-stable.txt)
+          X64=$(awk   '/claude-darwin-x64\.tar\.gz/{print $1}'   /tmp/shasums-stable.txt)
+          sed -i "s/version \"${OLD_VER}\"/version \"${NEW_VER}\"/" Casks/claude-code.rb
+          sed -i "s/arm:    \"[0-9a-f]\{64\}\"/arm:    \"${ARM64}\"/" Casks/claude-code.rb
+          sed -i "s/x86_64: \"[0-9a-f]\{64\}\"/x86_64: \"${X64}\"/"  Casks/claude-code.rb
+
+      - name: Update latest cask
+        if: steps.upstream.outputs.latest != steps.current.outputs.latest
+        env:
+          NEW_VER: ${{ steps.upstream.outputs.latest }}
+          OLD_VER: ${{ steps.current.outputs.latest }}
+        run: |
+          curl -fsSL "https://github.com/anthropics/claude-code/releases/download/v${NEW_VER}/SHASUMS256.txt" \
+            -o /tmp/shasums-latest.txt
+          ARM64=$(awk '/claude-darwin-arm64\.tar\.gz/{print $1}' /tmp/shasums-latest.txt)
+          X64=$(awk   '/claude-darwin-x64\.tar\.gz/{print $1}'   /tmp/shasums-latest.txt)
+          sed -i "s/version \"${OLD_VER}\"/version \"${NEW_VER}\"/" 'Casks/claude-code@latest.rb'
+          sed -i "s/arm:    \"[0-9a-f]\{64\}\"/arm:    \"${ARM64}\"/" 'Casks/claude-code@latest.rb'
+          sed -i "s/x86_64: \"[0-9a-f]\{64\}\"/x86_64: \"${X64}\"/"  'Casks/claude-code@latest.rb'
+
+      - name: Open PR if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STABLE_VER: ${{ steps.upstream.outputs.stable }}
+          LATEST_VER: ${{ steps.upstream.outputs.latest }}
+        run: |
+          if git diff --quiet; then
+            echo "Casks are up to date."
+            exit 0
+          fi
+
+          BRANCH="auto/claude-code-${LATEST_VER}"
+
+          if gh pr list --head "$BRANCH" --json number --jq '.[0].number' | grep -qE '^[0-9]+$'; then
+            echo "PR already open for $BRANCH — skipping."
+            exit 0
+          fi
+
+          git config user.email "robot@github.com"
+          git config user.name "homebrew-ih-public-action"
+          git checkout -b "$BRANCH"
+          git add Casks/claude-code.rb 'Casks/claude-code@latest.rb'
+          git commit -m "chore: update claude-code casks (stable=${STABLE_VER}, latest=${LATEST_VER})"
+          git push origin "$BRANCH"
+
+          printf 'Automated update of the Claude Code GitHub mirror casks.\n\nstable: %s\nlatest: %s\n\nChecksums sourced from upstream SHASUMS256.txt on each GitHub release.' \
+            "$STABLE_VER" "$LATEST_VER" > /tmp/pr-body.txt
+
+          gh pr create \
+            --title "chore: update claude-code casks (stable=${STABLE_VER}, latest=${LATEST_VER})" \
+            --body-file /tmp/pr-body.txt \
+            --base master \
+            --head "$BRANCH"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/update-claude-code-casks.yml` — a daily workflow that keeps the `claude-code` and `claude-code@latest` GitHub mirror casks in sync with upstream.

## How it works

1. Checks npm dist-tags (`stable`, `latest`) for `@anthropic-ai/claude-code`
2. Compares against current versions in each cask file
3. If different: downloads `SHASUMS256.txt` from the GitHub release, patches version + sha256s in-place with `sed`
4. Opens a PR on a version-stamped branch (`auto/claude-code-{latest_ver}`)
5. No-ops if casks are already current or a PR already exists for that version

Runs daily at 09:00 UTC. Can also be triggered manually via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation using public npm/GitHub release metadata; no runtime app or auth changes.
> 
> **Overview**
> Adds a **daily** (09:00 UTC) and **manual** GitHub Actions workflow that keeps the `claude-code` and `claude-code@latest` casks aligned with upstream `@anthropic-ai/claude-code` **stable** and **latest** npm dist-tags.
> 
> When versions differ, it fetches each release’s `SHASUMS256.txt`, updates version and **arm/x86_64** checksums in the cask files via `sed`, then opens a PR on `auto/claude-code-{latest}`—skipping if nothing changed or a PR for that branch already exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23aa488f0fd19157fc826df32b29632bb10b4992. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->