### PR TITLE
chore: exempt claude-code casks from code owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
 * @ConsultingMD/developer-platform
+
+# Claude Code mirror casks are auto-maintained by workflow — no code owner review required
+Casks/claude-code.rb
+Casks/claude-code@latest.rb
+.github/workflows/update-claude-code-casks.yml


### PR DESCRIPTION
## Summary

The `claude-code` and `claude-code@latest` casks are auto-maintained by the `update-claude-code-casks` workflow (PR #149). Requiring a code owner review on every automated version bump defeats the purpose of the automation.

This PR overrides the `*` wildcard for those three paths by adding blank-owner entries in CODEOWNERS, which removes the review requirement per [GitHub CODEOWNERS docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

**Files exempted:**
- `Casks/claude-code.rb`
- `Casks/claude-code@latest.rb`
- `.github/workflows/update-claude-code-casks.yml`

One-time approval needed from developer-platform — after this merges, automated PRs from the update workflow will auto-merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository policy-only change; no application code, auth, or runtime behavior is affected.
> 
> **Overview**
> Updates **`.github/CODEOWNERS`** so automated Claude Code cask bumps are not blocked by the repo-wide `@ConsultingMD/developer-platform` rule.
> 
> Adds **blank-owner** lines for `Casks/claude-code.rb`, `Casks/claude-code@latest.rb`, and `.github/workflows/update-claude-code-casks.yml`, which overrides the `*` entry and drops the required code-owner review on those paths per GitHub’s CODEOWNERS behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d037301465e600ba0e489e443be2b9b6427c61. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->