### PR TITLE
feat: VPN-safe claude-code casks with auto-update workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
 * @ConsultingMD/developer-platform
+
+# Claude Code mirror casks: version bumps are auto-merged without code owner review.
+# Workflow changes still require review from @ConsultingMD/developer-platform.
+Casks/claude-code.rb
+Casks/claude-code@latest.rb

--- a/.github/workflows/update-claude-code-casks.yml
+++ b/.github/workflows/update-claude-code-casks.yml
@@ -1,0 +1,91 @@
+name: update-claude-code-casks
+
+on:
+  schedule:
+    - cron: '0 9 * * *'  # Daily at 9am UTC
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get upstream versions
+        id: upstream
+        run: |
+          DIST_TAGS=$(npm view @anthropic-ai/claude-code dist-tags --json)
+          LATEST=$(echo "$DIST_TAGS" | jq -r '.latest')
+          STABLE=$(echo "$DIST_TAGS" | jq -r '.stable // .latest')
+          echo "stable=${STABLE}" >> "$GITHUB_OUTPUT"
+          echo "latest=${LATEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Get current cask versions
+        id: current
+        run: |
+          echo "stable=$(grep -m1 'version ' Casks/claude-code.rb | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+          echo "latest=$(grep -m1 'version ' 'Casks/claude-code@latest.rb' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+
+      - name: Update stable cask
+        if: steps.upstream.outputs.stable != steps.current.outputs.stable
+        env:
+          NEW_VER: ${{ steps.upstream.outputs.stable }}
+          OLD_VER: ${{ steps.current.outputs.stable }}
+        run: |
+          curl -fsSL "https://github.com/anthropics/claude-code/releases/download/v${NEW_VER}/SHASUMS256.txt" \
+            -o /tmp/shasums-stable.txt
+          ARM64=$(awk '/claude-darwin-arm64\.tar\.gz/{print $1}' /tmp/shasums-stable.txt)
+          X64=$(awk   '/claude-darwin-x64\.tar\.gz/{print $1}'   /tmp/shasums-stable.txt)
+          sed -i "s/version \"${OLD_VER}\"/version \"${NEW_VER}\"/" Casks/claude-code.rb
+          sed -i "s/arm:    \"[0-9a-f]\{64\}\"/arm:    \"${ARM64}\"/" Casks/claude-code.rb
+          sed -i "s/x86_64: \"[0-9a-f]\{64\}\"/x86_64: \"${X64}\"/"  Casks/claude-code.rb
+
+      - name: Update latest cask
+        if: steps.upstream.outputs.latest != steps.current.outputs.latest
+        env:
+          NEW_VER: ${{ steps.upstream.outputs.latest }}
+          OLD_VER: ${{ steps.current.outputs.latest }}
+        run: |
+          curl -fsSL "https://github.com/anthropics/claude-code/releases/download/v${NEW_VER}/SHASUMS256.txt" \
+            -o /tmp/shasums-latest.txt
+          ARM64=$(awk '/claude-darwin-arm64\.tar\.gz/{print $1}' /tmp/shasums-latest.txt)
+          X64=$(awk   '/claude-darwin-x64\.tar\.gz/{print $1}'   /tmp/shasums-latest.txt)
+          sed -i "s/version \"${OLD_VER}\"/version \"${NEW_VER}\"/" 'Casks/claude-code@latest.rb'
+          sed -i "s/arm:    \"[0-9a-f]\{64\}\"/arm:    \"${ARM64}\"/" 'Casks/claude-code@latest.rb'
+          sed -i "s/x86_64: \"[0-9a-f]\{64\}\"/x86_64: \"${X64}\"/"  'Casks/claude-code@latest.rb'
+
+      - name: Open PR if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STABLE_VER: ${{ steps.upstream.outputs.stable }}
+          LATEST_VER: ${{ steps.upstream.outputs.latest }}
+        run: |
+          if git diff --quiet; then
+            echo "Casks are up to date."
+            exit 0
+          fi
+
+          BRANCH="auto/claude-code-${LATEST_VER}"
+
+          if gh pr list --head "$BRANCH" --json number --jq '.[0].number' | grep -qE '^[0-9]+$'; then
+            echo "PR already open for $BRANCH — skipping."
+            exit 0
+          fi
+
+          git config user.email "robot@github.com"
+          git config user.name "homebrew-ih-public-action"
+          git checkout -b "$BRANCH"
+          git add Casks/claude-code.rb 'Casks/claude-code@latest.rb'
+          git commit -m "chore: update claude-code casks (stable=${STABLE_VER}, latest=${LATEST_VER})"
+          git push origin "$BRANCH"
+
+          printf 'Automated update of the Claude Code GitHub mirror casks.\n\nstable: %s\nlatest: %s\n\nChecksums sourced from upstream SHASUMS256.txt on each GitHub release.' \
+            "$STABLE_VER" "$LATEST_VER" > /tmp/pr-body.txt
+
+          PR_URL=$(gh pr create \
+            --title "chore: update claude-code casks (stable=${STABLE_VER}, latest=${LATEST_VER})" \
+            --body-file /tmp/pr-body.txt \
+            --base master \
+            --head "$BRANCH")
+
+          gh pr merge --squash --auto "$PR_URL" || echo "Auto-merge not available (code owner review required); PR opened for manual merge."

--- a/Casks/claude-code.rb
+++ b/Casks/claude-code.rb
@@ -1,9 +1,9 @@
-cask "claude-code@latest" do
+cask "claude-code" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.1.154"
-  sha256 arm:    "643ec0cfa324744c15f6bf552d3ce6e934c42651b56f40ea8d4ec4f653a9b49f",
-         x86_64: "352e504e405a25e5f2b44ae3758b6dced15371c5411486b2c3add4c3ac4a5000"
+  version "2.1.145"
+  sha256 arm:    "a385eb18d127b55cf2b1846d0a1771db335d9fdb1f6d1181f79343f61c95ba91",
+         x86_64: "4ad91d8572e242d860308319930f04f1110c6301670eef4ba896f02b9759e177"
 
   url "https://github.com/anthropics/claude-code/releases/download/v#{version}/claude-darwin-#{arch}.tar.gz"
   name "Claude Code"
@@ -11,11 +11,12 @@ cask "claude-code@latest" do
   homepage "https://claude.com/product/claude-code"
 
   livecheck do
-    url "https://github.com/anthropics/claude-code/releases/latest"
+    url "https://github.com/anthropics/claude-code/releases"
     strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  conflicts_with cask: "claude-code"
+  conflicts_with cask: "claude-code@latest"
 
   binary "claude"
 

--- a/README.md
+++ b/README.md
@@ -104,3 +104,31 @@ You can test the setup script against your actual $HOME by running `./meta/test 
 or `./meta/test bash`. This will start a new shell of the specified type without loading
 your existing .\*rc files. Be careful, as running steps in this mode will update your
 real $HOME directory with things.
+
+## Claude Code
+
+The official Homebrew cask downloads from `downloads.claude.ai`, which is blocked on the IH VPN. `npm install -g @anthropic-ai/claude-code` is deprecated by Anthropic (it still works, but is no longer the recommended install path) and also uses the same blocked CDN. This tap provides VPN-safe mirror casks that download from GitHub releases instead.
+
+### Installation
+
+```bash
+brew tap ConsultingMD/ih-public
+brew install --cask claude-code@latest
+```
+
+### Updating
+
+```bash
+brew upgrade claude-code@latest
+```
+
+A GitHub Actions workflow runs daily, checks npm for new releases, and opens a PR to bump the cask version and SHA. Once merged, running `brew upgrade claude-code@latest` picks up the new version.
+
+### Channels
+
+| Cask | npm dist-tag | Use when |
+|------|-------------|----------|
+| `claude-code@latest` | `latest` | You want the most recent release (recommended) |
+| `claude-code` | `stable` | You want the explicitly promoted stable release |
+
+Both casks are updated by the same daily workflow. If you are unsure which to use, install `claude-code@latest`.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,105 @@
+## Claude Code Cask Update Workflow — Troubleshooting
+
+### What the workflow does
+
+The `update-claude-code-casks.yml` GitHub Actions workflow runs on a daily schedule. It:
+
+1. Queries the npm registry for the current version of `@anthropic-ai/claude-code` at the `latest` (and `stable`) dist-tags.
+2. Downloads the corresponding `SHASUMS256.txt` release asset from the GitHub release.
+3. Extracts the SHA-256 for the `.zip` artifact.
+4. Uses `sed` to substitute the new version and SHA into each cask `.rb` file.
+5. Opens a PR with the changes if the version changed.
+6. Attempts to auto-merge the PR once CI passes.
+
+### Manually triggering the workflow
+
+**GitHub UI:** Go to Actions → "Update Claude Code Casks" → "Run workflow" → click "Run workflow".
+
+**gh CLI:**
+```bash
+gh workflow run update-claude-code-casks.yml --repo ConsultingMD/homebrew-ih-public
+```
+
+---
+
+### Common failure modes
+
+#### a. npm registry unreachable
+
+**Symptom:** Workflow fails at the `npm dist-tag ls` or `npm view` step with a network error or non-zero exit code.
+
+**Fix:** Re-run the workflow once the npm registry is reachable. No cask changes are needed.
+
+---
+
+#### b. SHASUMS256.txt not available
+
+**Symptom:** Workflow fails when downloading or parsing `SHASUMS256.txt`. The GitHub release may not yet have this asset attached, or the release may be delayed behind the npm publish.
+
+**Fix:** Wait 15–30 minutes for the release assets to appear, then re-trigger the workflow manually. If the asset never appears, check the upstream `anthropics/claude-code` releases page to confirm the release is complete.
+
+---
+
+#### c. sed substitution failed
+
+**Symptom:** The `sed` step exits non-zero, or the resulting `.rb` file still contains the old version/SHA. This usually means the version string format or SHA format changed in a way the pattern no longer matches.
+
+**Fix:**
+1. Open the failing cask file (e.g., `Casks/claude-code@latest.rb`).
+2. Identify the `version` and `sha256` lines.
+3. Update the `sed` pattern in the workflow to match the current format, or manually apply the substitution (see "Manually bumping a cask version" below) and open a PR.
+
+---
+
+#### d. PR creation failed — branch already exists
+
+**Symptom:** The `gh pr create` step fails with "A branch named X already exists."
+
+**Cause:** A previous run opened a PR that was not merged or closed, and the branch is still present.
+
+**Fix:**
+- If the existing PR is still valid, merge or close it first, then delete the branch.
+- If the PR is stale, close it, delete the branch, and re-run the workflow:
+  ```bash
+  gh pr close <PR_NUMBER> --repo ConsultingMD/homebrew-ih-public
+  git push origin --delete update-claude-code-<version>
+  ```
+
+---
+
+#### e. Auto-merge blocked — CODEOWNERS review required
+
+**Symptom:** The PR is created and CI passes but auto-merge does not fire. The PR shows "Review required."
+
+**Cause:** The CODEOWNERS rule exempts cask files from review, but the exemption only takes effect once the rule is on the default branch. If auto-merge is blocked, the exemption may not yet be active.
+
+**Fix:** Request a review from a member of `@ConsultingMD/developer-platform` and approve the PR manually.
+
+---
+
+### Manually bumping a cask version
+
+If the workflow is broken and you need to ship a version bump by hand:
+
+1. Find the new version:
+   ```bash
+   npm view @anthropic-ai/claude-code dist-tags
+   ```
+
+2. Download and inspect the SHA:
+   ```bash
+   VERSION=<new_version>
+   curl -fsSL "https://github.com/anthropics/claude-code/releases/download/v${VERSION}/SHASUMS256.txt"
+   ```
+   Copy the SHA-256 for the `.zip` artifact that the cask downloads.
+
+3. Edit the cask file (`Casks/claude-code@latest.rb`):
+   - Update the `version` line to the new version string.
+   - Update the `sha256` line to the new SHA.
+
+4. Verify the cask locally:
+   ```bash
+   brew audit --cask --new Casks/claude-code@latest.rb
+   ```
+
+5. Open a PR with the changes and request review.


### PR DESCRIPTION
## Summary

Adds two Homebrew casks that mirror Claude Code downloads from GitHub releases instead of \`downloads.claude.ai\` (blocked on IH VPN):

- **\`claude-code\`** — tracks the \`stable\` dist-tag
- **\`claude-code@latest\`** — tracks the \`latest\` dist-tag (already on master; this PR fixes it)

Both casks download from \`https://github.com/anthropics/claude-code/releases/\` — bypassing the VPN block.

> **Note:** \`npm install -g @anthropic-ai/claude-code\` is deprecated by Anthropic (it still works). Both the npm registry download and the official Homebrew cask use \`downloads.claude.ai\`, which is blocked on the IH VPN. This tap provides the VPN-safe alternative.

## Changes

### \`Casks/claude-code.rb\` (new)
Stable-channel cask. Tracks the npm \`stable\` dist-tag via livecheck. Conflicts with \`claude-code@latest\`.

### \`Casks/claude-code@latest.rb\` (fix)
Add bidirectional \`conflicts_with cask: "claude-code"\`. Previously the conflict was one-way, which allowed simultaneous installation (e.g. by Cursor bot).

### \`.github/workflows/update-claude-code-casks.yml\` (new)
Daily workflow (+ \`workflow_dispatch\`) that:
1. Checks npm for the current \`stable\` and \`latest\` versions
2. Fetches checksums from the GitHub release \`SHASUMS256.txt\`
3. Opens an auto-mergeable PR to bump both casks

The \`stable\` dist-tag falls back to \`latest\` if not set on the npm package.

> **To see the workflow run:** after this PR is merged to master, trigger it via:
> \`\`\`
> gh workflow run update-claude-code-casks.yml --repo ConsultingMD/homebrew-ih-public
> \`\`\`

### \`.github/CODEOWNERS\` (fix)
Exempts the two cask files from code owner review so auto-update PRs can merge without manual approval. **Workflow file changes still require \`@ConsultingMD/developer-platform\` review.**

## Supersedes
Closes #148, #149, #150

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New automation can open self-merge PRs that change install artifacts; risk is mitigated by checksums from official releases, but workflow/CODEOWNERS changes still affect supply-chain and review gates.
> 
> **Overview**
> Adds a **stable-channel** Homebrew cask (`claude-code`) that installs Claude Code from **GitHub releases** (same mirror pattern as the existing `claude-code@latest` cask), and wires **bidirectional** `conflicts_with` so only one channel can be installed at a time.
> 
> Introduces a **scheduled GitHub Action** (`update-claude-code-casks`) that reads npm `stable` / `latest` dist-tags, refreshes version and **darwin arm/x64** checksums from upstream `SHASUMS256.txt`, and opens **auto-merge** PRs when casks drift. **CODEOWNERS** is updated so routine cask bumps skip `@ConsultingMD/developer-platform` review while workflow edits still require it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8203348961abf97f64e6c77877950d73fa265143. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->