### PR TITLE
[DP-6821] Trust internal and required Homebrew taps

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -17,8 +17,8 @@ TAP_REPO="consultingmd/ih-public"
 
 # Check if the tap already exists, and if so, untap it to prevent issues caused by the old SSH url
 if brew tap | grep -q "$TAP_REPO"; then
-    echo "Homebrew tap $TAP_REPO already exists. Untapping..."
-    brew untap "$TAP_REPO"
+  echo "Homebrew tap $TAP_REPO already exists. Untapping..."
+  brew untap "$TAP_REPO"
 fi
 
 brew update
@@ -28,6 +28,15 @@ echo "Sometimes the dependency downloads fail, possibly due to the VPN, so \
 I will retry installing a couple times if it fails."
 
 brew tap ConsultingMD/homebrew-ih-public https://github.com/ConsultingMD/homebrew-ih-public.git
+
+# Trust our internal tap so Homebrew loads its formulae and casks without
+# warnings. From Homebrew 5.2.0/6.0.0 non-official taps must be explicitly
+# trusted (see https://docs.brew.sh/Tap-Trust). We administer this tap, so
+# whole-tap trust is appropriate. Guard on availability so this keeps working
+# on older Homebrew where 'brew trust' does not yet exist.
+if brew trust --help >/dev/null 2>&1; then
+  brew trust "$TAP_REPO"
+fi
 
 SUCCEEDED=1
 for _ in 1 2 3; do

--- a/lib/bobs/jdk/step.sh
+++ b/lib/bobs/jdk/step.sh
@@ -30,6 +30,16 @@ function ih::setup::bobs.jdk::install() {
   ih::log::info "Tapping adoptopenjdk/openjdk"
   ih::arch::ibrew tap adoptopenjdk/openjdk
 
+  # Trust the cask we install from this third-party tap. From Homebrew
+  # 5.2.0/6.0.0 non-official taps must be explicitly trusted to be loaded
+  # (see https://docs.brew.sh/Tap-Trust). Since we do not control this tap,
+  # trust only the specific cask rather than the whole tap. Guard on
+  # availability so older Homebrew (no 'brew trust') still works.
+  if ih::arch::ibrew trust --help >/dev/null 2>&1; then
+    ih::log::info "Trusting adoptopenjdk8 cask"
+    ih::arch::ibrew trust --cask adoptopenjdk/openjdk/adoptopenjdk8
+  fi
+
   ih::log::info "Installing adoptopenjdk8"
   ih::arch::ibrew install --cask adoptopenjdk8
 }


### PR DESCRIPTION
## What

Adds Homebrew [Tap Trust](https://docs.brew.sh/Tap-Trust) for the non-official taps this repo relies on.

Starting in Homebrew 5.2.0/6.0.0 (whichever lands first), non-official taps are no longer loaded by default — they must be explicitly trusted. Until then, `brew doctor` warns about untrusted non-official taps and install commands may print a warning before installing from them.

## Taps trusted

| Tap | Source | Trust scope |
|-----|--------|-------------|
| `consultingmd/ih-public` | `bootstrap` | Whole-tap — we administer it (provides `ih-core`, `ih-mcp-router`, `ih-rancher`, `claude-code`). |
| `adoptopenjdk/openjdk` | `lib/bobs/jdk/step.sh` | The `adoptopenjdk8` cask only — third-party tap we don't control, so trust just the item we need. |

Official Homebrew/core installs (`gh`, `scala@2.12`, `bazelisk`) are always trusted and need no change.

## How

- After tapping our internal tap in `bootstrap`, run `brew trust "$TAP_REPO"`.
- After tapping `adoptopenjdk` in the jdk step, run `brew trust --cask adoptopenjdk/openjdk/adoptopenjdk8`.
- Every `brew trust` call is guarded on `brew trust --help` so onboarding keeps working on Homebrew versions that predate the command.

`bootstrap` also picks up a small `shfmt` whitespace normalization (4-space → 2-space) of the pre-existing untap block, since pre-commit reformats the whole file once it's touched.

## Testing

- `shellcheck` and `shfmt` clean on both changed files.
- The guard means no behavior change on current Homebrew; on Homebrew with `brew trust`, the taps/cask are trusted right after they're added.

Ticket: DP-6821

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, conditional onboarding script changes with no effect on Homebrew versions that lack `brew trust`.
> 
> **Overview**
> Prepares engineer onboarding for Homebrew **Tap Trust**, where non-official taps stop loading unless explicitly trusted (Homebrew 5.2.0/6.0.0).
> 
> **`bootstrap`** now runs whole-tap `brew trust` on `consultingmd/ih-public` right after tapping it, so `ih-core` and related formulae install without warnings. The existing untap block is also normalized to 2-space indentation (shfmt).
> 
> **`lib/bobs/jdk/step.sh`** trusts only the `adoptopenjdk8` cask from `adoptopenjdk/openjdk` before install, since that tap is third-party. Both paths use a `brew trust --help` guard so older Homebrew without the command is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e10c2d095e65c1438213e3b8e6546df62b3120. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->