### PR TITLE
chore: deprecate claude-code@latest cask workaround

### DIFF
--- a/Casks/claude-code@latest.rb
+++ b/Casks/claude-code@latest.rb
@@ -15,6 +15,9 @@ cask "claude-code@latest" do
     strategy :github_latest
   end
 
+  deprecate! date:    "2026-07-01",
+             because: "is superseded by the official claude-code@latest cask, now reachable on the IH VPN"
+
   binary "claude"
 
   zap trash: [


### PR DESCRIPTION
## Summary

Marks the `claude-code@latest` cask (added in #147) as **deprecated**. It was a VPN-safe workaround that mirrored the official Homebrew cask, pulling the binary from GitHub releases because `downloads.claude.ai` was blocked on the IH VPN. The official cask/download path is now reachable on VPN, so the mirror is no longer needed.

This PR keeps the file for one release cycle with a `deprecate!` stanza so anyone who installed via this cask gets a migration warning on `brew` operations. The follow-up removal is tracked in a separate draft PR.

## Change
```ruby
deprecate! date:    "2026-07-01",
           because: "is superseded by the official claude-code@latest cask, now reachable on the IH VPN"
```

## Migration for existing users
```bash
brew uninstall --cask ConsultingMD/ih-public/claude-code@latest
brew install --cask claude-code@latest   # official cask
```

## Test plan
- [x] `brew style Casks/claude-code@latest.rb` — no offenses
- [ ] `brew audit --cask Casks/claude-code@latest.rb`
- [ ] Confirm the official cask is reachable on the IH VPN before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only cask change with no runtime or install logic changes beyond Homebrew deprecation warnings.
> 
> **Overview**
> Adds a **`deprecate!`** stanza to the **`claude-code@latest`** cask (effective **2026-07-01**), because the official Homebrew cask is now reachable on the IH VPN and this GitHub-release mirror is no longer needed.
> 
> The cask stays in the tap for one cycle so **`brew`** can warn existing installs to uninstall this tap cask and switch to the official **`claude-code@latest`** cask; removal is planned separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e69ef2eba888cd7da5831088b2dd2df116341b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->