### PR TITLE
[CLOUD-8124] Default and normalize IH_USERNAME to fix doubled JIRA_USERNAME

### DIFF
--- a/lib/core/shell/step.sh
+++ b/lib/core/shell/step.sh
@@ -234,9 +234,22 @@ function ih::setup::core.shell::private::configure-profile() {
   ih::setup::core.shell::private::collect-env-var "FULL_NAME" \
     "Your full name, the name you would introduce yourself with" \
     ""
+  # Default from the email collected just above: its local-part is the username, so
+  # people don't retype it and can't fat-finger a mismatch. collect-env-var only
+  # prompts when there's no default, so this derives the username automatically.
   ih::setup::core.shell::private::collect-env-var "IH_USERNAME" \
     "Your email username, likely firstname.lastname (without @includedhealth.com)" \
-    ""
+    "${EMAIL_ADDRESS%%@*}"
+  # IH_USERNAME should be just the email local-part (the prompt says so), but a full
+  # email can get pasted or already be saved that way. Strip the domain so IH_USERNAME
+  # and everything derived from it stay correct. Also drop a stale JIRA_USERNAME so it
+  # re-derives from the cleaned value below (collect-env-var keeps a set value as-is),
+  # which repairs the doubled domain older setups produced.
+  if [[ "$IH_USERNAME" == *@* ]]; then
+    ih::log::warn "IH_USERNAME should be just your email username; dropping the domain and using '${IH_USERNAME%%@*}'."
+    export IH_USERNAME="${IH_USERNAME%%@*}"
+    unset JIRA_USERNAME
+  fi
   # shellcheck disable=SC2153
   export GR_USERNAME="$IH_USERNAME"
   local default_jira_username="$GR_USERNAME@includedhealth.com"
@@ -322,6 +335,14 @@ function ih::setup::core.shell::private::validate-profile() {
       return 1 # Return 1 as soon as an unset variable is found
     fi
   done
+
+  # IH_USERNAME must be just the email local-part. A domain here is the root cause of
+  # the doubled JIRA_USERNAME that broke Jira auth in older setups, so treat the
+  # profile as out of sync. Re-running strips it and re-derives JIRA_USERNAME.
+  if [[ "$IH_USERNAME" == *@* ]]; then
+    ih::log::debug "IH_USERNAME contains a domain and needs normalizing"
+    return 1
+  fi
 
   return 0 # Return 0 if all variables are set
 }

--- a/lib/core/shell/step.sh
+++ b/lib/core/shell/step.sh
@@ -238,7 +238,7 @@ function ih::setup::core.shell::private::configure-profile() {
   # people don't retype it and can't fat-finger a mismatch. collect-env-var only
   # prompts when there's no default, so this derives the username automatically.
   ih::setup::core.shell::private::collect-env-var "IH_USERNAME" \
-    "Your email username, likely firstname.lastname (without @includedhealth.com)" \
+    "The part of your email before the @ (likely firstname.lastname), not the full address" \
     "${EMAIL_ADDRESS%%@*}"
   # IH_USERNAME should be just the email local-part (the prompt says so), but a full
   # email can get pasted or already be saved that way. Strip the domain so IH_USERNAME
@@ -246,7 +246,7 @@ function ih::setup::core.shell::private::configure-profile() {
   # re-derives from the cleaned value below (collect-env-var keeps a set value as-is),
   # which repairs the doubled domain older setups produced.
   if [[ "$IH_USERNAME" == *@* ]]; then
-    ih::log::warn "IH_USERNAME should be just your email username; dropping the domain and using '${IH_USERNAME%%@*}'."
+    ih::log::warn "IH_USERNAME should be just the part of your email before the @ (like firstname.lastname), not the full address. Using '${IH_USERNAME%%@*}'."
     export IH_USERNAME="${IH_USERNAME%%@*}"
     unset JIRA_USERNAME
   fi


### PR DESCRIPTION
## Problem
`ih-setup` builds `JIRA_USERNAME` by appending `@includedhealth.com` to `IH_USERNAME` without validating it. When someone enters their full email at the `IH_USERNAME` prompt (easy to do, and older prompts didn't warn against it), the result is a doubled domain like `name@includedhealth.com@includedhealth.com`. That value gets saved to `00_env.sh`, fails Jira auth with a 401 on `/rest/api/3/myself`, blocks the `core jira` token step and `jsm-notify-setup`, and breaks other tools that read the same variable such as `make-branch` and `tng`. @PenguinDan saw this came up during the PagerDuty to JSM migration setup.

## Solution
Default `IH_USERNAME` from the email address collected one prompt earlier, so the username is derived rather than retyped and a fresh setup can't produce a bad value. If `IH_USERNAME` still carries a domain (a pasted email or a value saved before this fix), strip it and clear the derived `JIRA_USERNAME` so it re-derives from the cleaned username. `validate-profile` also flags a domain in `IH_USERNAME` so an already-broken machine reports out of sync and a re-run repairs it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to ih-setup profile prompting and validation; no auth or runtime behavior changes beyond correcting saved env vars.
> 
> **Overview**
> Fixes **Jira auth failures** when `IH_USERNAME` was entered or saved as a full email, which made `JIRA_USERNAME` become `user@includedhealth.com@includedhealth.com`.
> 
> During **`configure-profile`**, `IH_USERNAME` now **defaults** to the local part of `EMAIL_ADDRESS` (so users don’t retype it). If the value still contains `@`, setup **strips the domain**, warns, and **clears `JIRA_USERNAME`** so it is rebuilt from the cleaned username before the Jira prompt runs.
> 
> **`validate-profile`** also treats a domain in `IH_USERNAME` as invalid so `ih-setup` reports the shell step out of sync and a re-run can repair existing broken `00_env.sh` profiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d6f60359fb2ed01e64b5de9dd3476442985e0fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->